### PR TITLE
Add 2.0.9 regression test

### DIFF
--- a/minimatch.js
+++ b/minimatch.js
@@ -378,7 +378,7 @@ function parse (pattern, isSub) {
           start: i - 1,
           reStart: re.length
         })
-        // negation is (?:(?!js)[^/]*)
+        // negation is (?:(?!(?:js))[^/]*)
         re += stateChar === '!' ? '(?:(?!(?:' : '(?:'
         this.debug('plType %j %j', stateChar, re)
         stateChar = false
@@ -395,7 +395,7 @@ function parse (pattern, isSub) {
         re += ')'
         var pl = patternListStack.pop()
         plType = pl.type
-        // negation is (?:(?!js)[^/]*)
+        // negation is (?:(?!(?:js))[^/]*)
         // The others are (?:<pattern>)<type>
         switch (plType) {
           case '!':

--- a/test/patterns.js
+++ b/test/patterns.js
@@ -259,7 +259,15 @@ module.exports = [
   'https://github.com/isaacs/minimatch/issues/59',
   ['[z-a]', []],
   ['a/[2015-03-10T00:23:08.647Z]/z', []],
-  ['[a-0][a-\u0100]', []]
+  ['[a-0][a-\u0100]', []],
+
+  'v2.0.8 -> v2.0.9 regression',
+  [
+    '*(*.json|!(*.js))',
+    ['testjson.json', 'other.bar'],
+    {},
+    ['testjson.json', 'foojs.js', 'other.bar']
+  ]
 ]
 
 module.exports.regexps = [
@@ -358,7 +366,8 @@ module.exports.regexps = [
   '/^(?:(?:(?!(?:\\/|^)\\.).)*?\\/\\.x\\/(?:(?!(?:\\/|^)\\.).)*?)$/',
   '/^(?:\\[z\\-a\\])$/',
   '/^(?:a\\/\\[2015\\-03\\-10T00:23:08\\.647Z\\]\\/z)$/',
-  '/^(?:(?=.)\\[a-0\\][a-Ā])$/'
+  '/^(?:(?=.)\\[a-0\\][a-Ā])$/',
+  '/^(?:(?!\\.)(?=.)(?:[^\\/]*?\\.json|(?:(?![^\\/]*?\\.js)[^\\/]*?))*)$/'
 ]
 
 Object.defineProperty(module.exports, 'files', {


### PR DESCRIPTION
Test passes on 2.0.8 but 2.0.9 generates an invalid regex:

```
  not ok SyntaxError: Invalid regular expression: /^(?!\.)(?=.)(?:[^/]*?\.json|(?:(?!(?:[^/]*?\.js))*)[^/]*?))*$/: Unmatched ')'
    test: basic tests
    message: "SyntaxError: Invalid regular expression: /^(?!\\.)(?=.)(?:[^/]*?\\.json|(?:(?!(?:[^/]*?\\.js))*)[^/]*?))*$/: Unmatched ')'"
    stack: |
      new RegExp (<anonymous>)
      Minimatch.parse (minimatch.js:605:16)
      Array.map (native)
      Minimatch.<anonymous> (minimatch.js:174:14)
      Array.map (native)
      Minimatch.make (minimatch.js:173:13)
      new Minimatch (minimatch.js:128:8)
      test/defaults.js:28:13
      Array.forEach (native)
      test/defaults.js:16:12
```
